### PR TITLE
feat: 🎸 add `getSenderProofs` method to ConfidentialTransaction

### DIFF
--- a/src/api/entities/confidential/ConfidentialTransaction/types.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/types.ts
@@ -117,3 +117,13 @@ export type AffirmConfidentialTransactionParams = { legId: BigNumber } & (
   | SenderAffirm
   | ObserverAffirm
 );
+
+export interface SenderAssetProof {
+  proof: string;
+  assetId: string;
+}
+
+export type SenderProofs = {
+  legId: BigNumber;
+  proofs: SenderAssetProof[];
+};

--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -10,6 +10,7 @@ import {
   PolymeshError,
   PolymeshTransaction,
 } from '~/internal';
+import { getConfidentialTransactionProofsQuery } from '~/middleware/queries';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import {
   createMockConfidentialAssetTransaction,
@@ -559,6 +560,45 @@ describe('ConfidentialTransaction class', () => {
   describe('method: toHuman', () => {
     it('should return a human readable version of the entity', () => {
       expect(transaction.toHuman()).toBe('1');
+    });
+  });
+
+  describe('method: getSenderProofs', () => {
+    it('should return the query results', async () => {
+      const senderProofsResult = {
+        confidentialTransactionAffirmations: {
+          nodes: [
+            {
+              legId: 1,
+              proofs: [
+                {
+                  assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa',
+                  proof: '0xsomeProof',
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      dsMockUtils.createApolloQueryMock(
+        getConfidentialTransactionProofsQuery(transaction.id),
+        senderProofsResult
+      );
+
+      const result = await transaction.getSenderProofs();
+
+      expect(result).toEqual([
+        {
+          legId: new BigNumber('1'),
+          proofs: [
+            {
+              assetId: '08abb6e3-550f-3857-21cf-d4a35bd5c6fa',
+              proof: '0xsomeProof',
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/src/middleware/queries/confidential.ts
+++ b/src/middleware/queries/confidential.ts
@@ -282,3 +282,55 @@ export function getConfidentialAssetHistoryByConfidentialAccountQuery(
     variables: { ...variables, size: size?.toNumber(), start: start?.toNumber() },
   };
 }
+
+export type ConfidentialTransactionProofsArgs = {
+  transactionId: string;
+};
+
+/**
+ * @hidden
+ */
+function createGetConfidentialTransactionProofArgs(transactionId: BigNumber): {
+  args: string;
+  filter: string;
+  variables: { transactionId: string };
+} {
+  const args = ['$transactionId: String!'];
+  const filter = ['transactionId: { equalTo: $transactionId }'];
+
+  return {
+    args: `(${args.join()})`,
+    filter: `filter: { ${filter.join()} }`,
+    variables: { transactionId: transactionId.toString() },
+  };
+}
+
+/**
+ * @hidden
+ *
+ * Get sender proofs for a transaction
+ */
+export function getConfidentialTransactionProofsQuery(
+  transactionId: BigNumber
+): QueryOptions<ConfidentialTransactionProofsArgs> {
+  const { args, filter, variables } = createGetConfidentialTransactionProofArgs(transactionId);
+
+  const query = gql`
+  query ConfidentialTransactionProofs
+  ${args}
+  {
+    confidentialTransactionAffirmations(
+      ${filter}
+  ) {
+    nodes {
+      proofs
+      legId
+    }
+  }
+  }`;
+
+  return {
+    query,
+    variables,
+  };
+}


### PR DESCRIPTION


### Description

allow users to get all sender proofs for a transaction

### Breaking Changes

None

### JIRA Link

Prerequisite for [DA-1120](https://polymesh.atlassian.net/browse/DA-1120)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1120]: https://polymesh.atlassian.net/browse/DA-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ