### PR TITLE
fix: 🐛 filter for sender in getSenderProofs

### DIFF
--- a/src/middleware/queries/confidential.ts
+++ b/src/middleware/queries/confidential.ts
@@ -296,7 +296,7 @@ function createGetConfidentialTransactionProofArgs(transactionId: BigNumber): {
   variables: { transactionId: string };
 } {
   const args = ['$transactionId: String!'];
-  const filter = ['transactionId: { equalTo: $transactionId }'];
+  const filter = ['transactionId: { equalTo: $transactionId }, party: { equalTo: Sender }'];
 
   return {
     args: `(${args.join()})`,


### PR DESCRIPTION
### Description

filter for sender in getSenderProofs. non senders would have null proof, causing a type error

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
