### PR TITLE
fix: 🐛 order confidential tx legs according to ID

### DIFF
--- a/src/api/entities/confidential/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/index.ts
@@ -308,7 +308,7 @@ export class ConfidentialTransaction extends Entity<UniqueIdentifiers, string> {
       };
     });
 
-    return legs;
+    return legs.sort((a, b) => a.id.minus(b.id).toNumber());
   }
 
   /**
@@ -329,16 +329,18 @@ export class ConfidentialTransaction extends Entity<UniqueIdentifiers, string> {
 
     const rawLegStates = await confidentialAsset.txLegStates.entries(rawId);
 
-    return rawLegStates.map(([key, rawLegState]) => {
-      const rawLegId = key.args[1];
-      const legId = confidentialTransactionLegIdToBigNumber(rawLegId);
-      const state = confidentialLegStateToLegState(rawLegState, context);
+    return rawLegStates
+      .map(([key, rawLegState]) => {
+        const rawLegId = key.args[1];
+        const legId = confidentialTransactionLegIdToBigNumber(rawLegId);
+        const state = confidentialLegStateToLegState(rawLegState, context);
 
-      return {
-        legId,
-        ...state,
-      };
-    });
+        return {
+          legId,
+          ...state,
+        };
+      })
+      .sort((a, b) => a.legId.minus(b.legId).toNumber());
   }
 
   /**


### PR DESCRIPTION
### Description

sort confidential legs so array index is always equal to legId

### Breaking Changes

None

### JIRA Link

✅ Closes: [DA-1128](https://polymesh.atlassian.net/browse/DA-1128)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1128]: https://polymesh.atlassian.net/browse/DA-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ