### PR TITLE
feat: 🎸 Add `createdAt` method to `ConfidentialTransaction`

### DIFF
--- a/src/api/entities/confidential/ConfidentialTransaction/types.ts
+++ b/src/api/entities/confidential/ConfidentialTransaction/types.ts
@@ -61,6 +61,9 @@ export enum ConfidentialTransactionStatus {
  */
 export interface ConfidentialTransactionDetails {
   venueId: BigNumber;
+  /**
+   * block number at which the Confidential Transaction was created
+   */
   createdAt: BigNumber;
   status: ConfidentialTransactionStatus;
   memo?: string;

--- a/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialTransaction/index.ts
@@ -10,7 +10,10 @@ import {
   PolymeshError,
   PolymeshTransaction,
 } from '~/internal';
-import { getConfidentialTransactionProofsQuery } from '~/middleware/queries';
+import {
+  confidentialTransactionQuery,
+  getConfidentialTransactionProofsQuery,
+} from '~/middleware/queries';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import {
   createMockConfidentialAssetTransaction,
@@ -666,6 +669,46 @@ describe('ConfidentialTransaction class', () => {
           ],
         },
       ]);
+    });
+  });
+
+  describe('method: createdAt', () => {
+    it('should return the event identifier object of the ConfidentialTransaction creation', async () => {
+      const eventIdx = new BigNumber(1);
+      const blockNumber = new BigNumber(1234);
+      const blockHash = 'someHash';
+      const blockDate = new Date('4/14/2020');
+
+      const fakeResult = { blockNumber, blockHash, blockDate, eventIndex: eventIdx };
+
+      dsMockUtils.createApolloQueryMock(
+        confidentialTransactionQuery({ id: transaction.id.toString() }),
+        {
+          confidentialTransaction: {
+            createdBlock: {
+              blockId: blockNumber.toNumber(),
+              datetime: blockDate,
+              hash: blockHash,
+            },
+            eventIdx: eventIdx.toNumber(),
+          },
+        }
+      );
+
+      const result = await transaction.createdAt();
+
+      expect(result).toEqual(fakeResult);
+    });
+
+    it('should return null if the query result is empty', async () => {
+      dsMockUtils.createApolloQueryMock(
+        confidentialTransactionQuery({ id: transaction.id.toString() }),
+        {
+          confidentialTransaction: null,
+        }
+      );
+      const result = await transaction.createdAt();
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/middleware/__tests__/queries/confidential.ts
+++ b/src/middleware/__tests__/queries/confidential.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js';
 import {
   confidentialAssetQuery,
   confidentialAssetsByHolderQuery,
+  confidentialTransactionQuery,
   getConfidentialAssetHistoryByConfidentialAccountQuery,
   getConfidentialTransactionsByConfidentialAccountQuery,
 } from '~/middleware/queries';
@@ -214,5 +215,18 @@ describe('getConfidentialAssetHistoryByConfidentialAccountQuery', () => {
       start: start.toNumber(),
       accountId,
     });
+  });
+});
+
+describe('confidentialTransactionQuery', () => {
+  it('should pass the variables to the grapqhl query', () => {
+    const variables = {
+      id: '1',
+    };
+
+    const result = confidentialTransactionQuery(variables);
+
+    expect(result.query).toBeDefined();
+    expect(result.variables).toEqual(variables);
   });
 });

--- a/src/middleware/queries/confidential.ts
+++ b/src/middleware/queries/confidential.ts
@@ -7,6 +7,7 @@ import {
   ConfidentialAssetHistory,
   ConfidentialAssetHolder,
   ConfidentialAssetHoldersOrderBy,
+  ConfidentialTransaction,
   ConfidentialTransactionStatusEnum,
   EventIdEnum,
 } from '~/middleware/types';
@@ -328,6 +329,33 @@ export function getConfidentialTransactionProofsQuery(
     }
   }
   }`;
+
+  return {
+    query,
+    variables,
+  };
+}
+
+/**
+ * @hidden
+ *
+ * Get confidential transaction details by ID
+ */
+export function confidentialTransactionQuery(
+  variables: QueryArgs<ConfidentialTransaction, 'id'>
+): QueryOptions<QueryArgs<ConfidentialTransaction, 'id'>> {
+  const query = gql`
+    query ConfidentialTransaction($id: String!) {
+      confidentialTransaction(id: $id) {
+        eventIdx
+        createdBlock {
+          blockId
+          datetime
+          hash
+        }
+      }
+    }
+  `;
 
   return {
     query,


### PR DESCRIPTION
### Description

Add `createdAt` method to `ConfidentialTransaction`. This returns the identifier data for the transaction created event.

### Breaking Changes

NA

### JIRA Link

DA-1119

### Checklist

- [ ] Updated the Readme.md (if required) ?
