### PR TITLE
feat: 🎸 Export public entities, utils and consts

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@polkadot/api": "10.9.1",
     "@polkadot/util": "12.4.2",
     "@polkadot/util-crypto": "12.4.2",
-    "@polymeshassociation/polymesh-sdk": "24.1.0",
+    "@polymeshassociation/polymesh-sdk": "24.2.1",
     "bignumber.js": "9.0.1",
     "bluebird": "^3.7.2",
     "cross-fetch": "^4.0.0",

--- a/sdk-docs-typedoc.json
+++ b/sdk-docs-typedoc.json
@@ -7,7 +7,7 @@
     "src/generated/types.ts",
     "src/types/index.ts",
     "src/types/utils",
-    "src/utils/index.ts",
+    "src/entities/types.ts",
     "src/base"
   ],
   "entryPointStrategy": "expand",

--- a/sdk-docs-typedoc.json
+++ b/sdk-docs-typedoc.json
@@ -19,7 +19,6 @@
     "src/base/Context.ts",
     "src/base/Procedure.ts",
     "**/sandbox.ts",
-    "src/api/entities/types.ts",
     "src/api/entities/Namespace.ts",
     "src/types/internal.ts",
     "src/utils/**",

--- a/src/api/client/Polymesh.ts
+++ b/src/api/client/Polymesh.ts
@@ -19,10 +19,9 @@ import {
 import { SigningManager } from '@polymeshassociation/signing-manager-types';
 
 import { ConfidentialAccounts } from '~/api/client/ConfidentialAccounts';
+import { ConfidentialAssets } from '~/api/client/ConfidentialAssets';
 import { ConfidentialSettlements } from '~/api/client/ConfidentialSettlements';
 import schema from '~/polkadot/schema';
-
-import { ConfidentialAssets } from './ConfidentialAssets';
 
 export interface ConnectParams {
   /**

--- a/src/api/entities/ConfidentialAsset/types.ts
+++ b/src/api/entities/ConfidentialAsset/types.ts
@@ -1,9 +1,7 @@
 import { EventIdEnum } from '@polymeshassociation/polymesh-sdk/middleware/types';
-import { Identity } from '@polymeshassociation/polymesh-sdk/types';
 import BigNumber from 'bignumber.js';
 
-import { ConfidentialVenue } from '~/internal';
-import { ConfidentialAccount } from '~/types';
+import { ConfidentialAccount, ConfidentialVenue, Identity } from '~/internal';
 
 export interface ConfidentialAssetDetails {
   owner: Identity;

--- a/src/api/entities/Identity/__tests__/index.ts
+++ b/src/api/entities/Identity/__tests__/index.ts
@@ -1,0 +1,158 @@
+import { u64 } from '@polkadot/types';
+import { PolymeshPrimitivesIdentityId } from '@polkadot/types/lookup';
+import BigNumber from 'bignumber.js';
+import { when } from 'jest-when';
+
+import { Context, Entity, Identity } from '~/internal';
+import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
+import { MockContext } from '~/testUtils/mocks/dataSources';
+import { ConfidentialLegParty } from '~/types';
+import { tuple } from '~/types/utils';
+import * as utilsConversionModule from '~/utils/conversion';
+
+jest.mock(
+  '~/api/entities/ConfidentialAsset',
+  require('~/testUtils/mocks/entities').mockConfidentialAssetModule(
+    '~/api/entities/ConfidentialAsset'
+  )
+);
+
+jest.mock(
+  '~/api/entities/ConfidentialVenue',
+  require('~/testUtils/mocks/entities').mockConfidentialVenueModule(
+    '~/api/entities/ConfidentialVenue'
+  )
+);
+
+describe('Identity class', () => {
+  let context: MockContext;
+  let stringToIdentityIdSpy: jest.SpyInstance<PolymeshPrimitivesIdentityId, [string, Context]>;
+  let u64ToBigNumberSpy: jest.SpyInstance<BigNumber, [u64]>;
+
+  beforeAll(() => {
+    dsMockUtils.initMocks();
+    entityMockUtils.initMocks();
+    procedureMockUtils.initMocks();
+    stringToIdentityIdSpy = jest.spyOn(utilsConversionModule, 'stringToIdentityId');
+    u64ToBigNumberSpy = jest.spyOn(utilsConversionModule, 'u64ToBigNumber');
+  });
+
+  beforeEach(() => {
+    context = dsMockUtils.getContextInstance({
+      middlewareEnabled: true,
+    });
+  });
+
+  afterEach(() => {
+    dsMockUtils.reset();
+    entityMockUtils.reset();
+    procedureMockUtils.reset();
+  });
+
+  afterAll(() => {
+    dsMockUtils.cleanup();
+    procedureMockUtils.cleanup();
+  });
+
+  it('should extend Entity', () => {
+    expect(Identity.prototype instanceof Entity).toBe(true);
+  });
+
+  describe('constructor', () => {
+    it('should assign did to instance', () => {
+      const did = 'abc';
+      const identity = new Identity({ did }, context);
+
+      expect(identity.did).toBe(did);
+    });
+  });
+
+  describe('method: isUniqueIdentifiers', () => {
+    it('should return true if the object conforms to the interface', () => {
+      expect(Identity.isUniqueIdentifiers({ did: 'someDid' })).toBe(true);
+      expect(Identity.isUniqueIdentifiers({})).toBe(false);
+      expect(Identity.isUniqueIdentifiers({ did: 3 })).toBe(false);
+    });
+  });
+
+  describe('method: getInvolvedConfidentialTransactions', () => {
+    const transactionId = new BigNumber(1);
+    const legId = new BigNumber(2);
+
+    it('should return the transactions with the identity affirmation status', async () => {
+      dsMockUtils.createQueryMock('confidentialAsset', 'userAffirmations', {
+        entries: [
+          tuple(
+            [
+              dsMockUtils.createMockIdentityId('someDid'),
+              [
+                dsMockUtils.createMockConfidentialTransactionId(transactionId),
+                dsMockUtils.createMockConfidentialTransactionLegId(legId),
+                dsMockUtils.createMockConfidentialLegParty('Sender'),
+              ],
+            ],
+            dsMockUtils.createMockOption(dsMockUtils.createMockBool(false))
+          ),
+        ],
+      });
+
+      const identity = new Identity({ did: 'someDid' }, context);
+
+      const result = await identity.getInvolvedConfidentialTransactions();
+
+      expect(result).toEqual({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            affirmed: false,
+            legId: new BigNumber(2),
+            role: ConfidentialLegParty.Sender,
+            transaction: expect.objectContaining({ id: transactionId }),
+          }),
+        ]),
+        next: null,
+      });
+    });
+  });
+
+  describe('method: getConfidentialVenues', () => {
+    let did: string;
+    let confidentialVenueId: BigNumber;
+
+    let rawDid: PolymeshPrimitivesIdentityId;
+    let rawConfidentialVenueId: u64;
+
+    beforeAll(() => {
+      did = 'someDid';
+      confidentialVenueId = new BigNumber(5);
+
+      rawDid = dsMockUtils.createMockIdentityId(did);
+      rawConfidentialVenueId = dsMockUtils.createMockU64(confidentialVenueId);
+    });
+
+    beforeEach(() => {
+      when(stringToIdentityIdSpy).calledWith(did, context).mockReturnValue(rawDid);
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return a list of Confidential Venues', async () => {
+      when(u64ToBigNumberSpy)
+        .calledWith(rawConfidentialVenueId)
+        .mockReturnValue(confidentialVenueId);
+
+      const mock = dsMockUtils.createQueryMock('confidentialAsset', 'identityVenues');
+      const mockStorageKey = { args: [rawDid, rawConfidentialVenueId] };
+
+      mock.keys = jest.fn().mockResolvedValue([mockStorageKey]);
+
+      const identity = new Identity({ did }, context);
+
+      const result = await identity.getConfidentialVenues();
+      expect(result).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: confidentialVenueId })])
+      );
+    });
+  });
+});

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -1,0 +1,110 @@
+import { Identity as PublicIdentity } from '@polymeshassociation/polymesh-sdk/internal';
+import {
+  boolToBoolean,
+  stringToIdentityId,
+  u64ToBigNumber,
+} from '@polymeshassociation/polymesh-sdk/utils/conversion';
+import { requestPaginated } from '@polymeshassociation/polymesh-sdk/utils/internal';
+
+import { ConfidentialTransaction, ConfidentialVenue } from '~/internal';
+import { ConfidentialAffirmation, PaginationOptions, ResultSet } from '~/types';
+import {
+  confidentialLegPartyToRole,
+  confidentialTransactionIdToBigNumber,
+  confidentialTransactionLegIdToBigNumber,
+} from '~/utils/conversion';
+
+/**
+ * Properties that uniquely identify an Identity
+ */
+export interface UniqueIdentifiers {
+  did: string;
+}
+
+/**
+ * Represents an Identity in the Polymesh blockchain
+ */
+export class Identity extends PublicIdentity {
+  /**
+   * @hidden
+   * Checks if a value is of type {@link UniqueIdentifiers}
+   */
+  public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
+    const { did } = identifier as UniqueIdentifiers;
+
+    return typeof did === 'string';
+  }
+
+  /**
+   * Get Confidential Transactions affirmations involving this identity
+   *
+   * @note supports pagination
+   */
+  public async getInvolvedConfidentialTransactions(
+    paginationOpts?: PaginationOptions
+  ): Promise<ResultSet<ConfidentialAffirmation>> {
+    const {
+      did,
+      context,
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+    } = this;
+
+    const { entries, lastKey: next } = await requestPaginated(confidentialAsset.userAffirmations, {
+      arg: did,
+      paginationOpts,
+    });
+
+    const data = entries.map(entry => {
+      const [key, value] = entry;
+      const affirmed = boolToBoolean(value.unwrap());
+      const [rawTransactionId, rawLegId, rawLegParty] = key.args[1];
+
+      const transactionId = confidentialTransactionIdToBigNumber(rawTransactionId);
+      const legId = confidentialTransactionLegIdToBigNumber(rawLegId);
+      const role = confidentialLegPartyToRole(rawLegParty);
+
+      const transaction = new ConfidentialTransaction({ id: transactionId }, context);
+
+      return {
+        affirmed,
+        legId,
+        transaction,
+        role,
+      };
+    });
+
+    return {
+      data,
+      next,
+    };
+  }
+
+  /**
+   * Retrieve all Confidential Venues created by this Identity
+   */
+  public async getConfidentialVenues(): Promise<ConfidentialVenue[]> {
+    const {
+      context: {
+        polymeshApi: {
+          query: { confidentialAsset },
+        },
+      },
+      did,
+      context,
+    } = this;
+
+    const rawDid = stringToIdentityId(did, context);
+
+    const venueIdsKeys = await confidentialAsset.identityVenues.keys(rawDid);
+
+    return venueIdsKeys.map(key => {
+      const rawVenueId = key.args[1];
+
+      return new ConfidentialVenue({ id: u64ToBigNumber(rawVenueId) }, context);
+    });
+  }
+}

--- a/src/api/entities/Identity/index.ts
+++ b/src/api/entities/Identity/index.ts
@@ -26,16 +26,6 @@ export interface UniqueIdentifiers {
  */
 export class Identity extends PublicIdentity {
   /**
-   * @hidden
-   * Checks if a value is of type {@link UniqueIdentifiers}
-   */
-  public static override isUniqueIdentifiers(identifier: unknown): identifier is UniqueIdentifiers {
-    const { did } = identifier as UniqueIdentifiers;
-
-    return typeof did === 'string';
-  }
-
-  /**
    * Get Confidential Transactions affirmations involving this identity
    *
    * @note supports pagination

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -1,10 +1,17 @@
+import { Identity as PublicIdentityClass } from '@polymeshassociation/polymesh-sdk/internal';
+
 import {
   ConfidentialAccount as ConfidentialAccountClass,
   ConfidentialAsset as ConfidentialAssetClass,
   ConfidentialTransaction as ConfidentialTransactionClass,
   ConfidentialVenue as ConfidentialVenueClass,
+  Identity as IdentityClass,
 } from '~/internal';
 
+export * from '@polymeshassociation/polymesh-sdk/api/entities/types';
+
+export type Identity = IdentityClass;
+export type PublicIdentity = PublicIdentityClass;
 export type ConfidentialAccount = ConfidentialAccountClass;
 export type ConfidentialAsset = ConfidentialAssetClass;
 export type ConfidentialVenue = ConfidentialVenueClass;

--- a/src/api/entities/types.ts
+++ b/src/api/entities/types.ts
@@ -1,5 +1,14 @@
-import { Identity as PublicIdentityClass } from '@polymeshassociation/polymesh-sdk/internal';
+import {
+  BaseAsset,
+  Identity as PublicIdentityClass,
+} from '@polymeshassociation/polymesh-sdk/internal';
+import {
+  DefaultPortfolio,
+  NumberedPortfolio,
+  SignerType,
+} from '@polymeshassociation/polymesh-sdk/types';
 
+import { TxTag } from '~/generated/types';
 import {
   ConfidentialAccount as ConfidentialAccountClass,
   ConfidentialAsset as ConfidentialAssetClass,
@@ -17,6 +26,43 @@ export type ConfidentialAsset = ConfidentialAssetClass;
 export type ConfidentialVenue = ConfidentialVenueClass;
 export type ConfidentialTransaction = ConfidentialTransactionClass;
 
+export * from './ConfidentialAccount/types';
 export * from './ConfidentialAsset/types';
 export * from './ConfidentialTransaction/types';
-export * from './ConfidentialAccount/types';
+
+/**
+ * This represents positive permissions (i.e. only "includes"). It is used
+ *   for specifying procedure requirements and querying if an Account has certain
+ *   permissions. Null values represent full permissions in that category
+ */
+export interface SimplePermissions {
+  /**
+   * list of required Asset permissions
+   */
+  assets?: BaseAsset[] | null;
+  /**
+   * list of required Transaction permissions
+   */
+  transactions?: TxTag[] | null;
+  portfolios?: (DefaultPortfolio | NumberedPortfolio)[] | null;
+}
+
+/**
+ * Result of a `checkPermissions` call. If `Type` is `Account`, represents whether the Account
+ *   has all the necessary secondary key Permissions. If `Type` is `Identity`, represents whether the
+ *   Identity has all the necessary external agent Permissions
+ */
+export interface CheckPermissionsResult<Type extends SignerType> {
+  /**
+   * required permissions which the signer *DOESN'T* have. Only present if `result` is `false`
+   */
+  missingPermissions?: Type extends SignerType.Account ? SimplePermissions : TxTag[] | null;
+  /**
+   * whether the signer complies with the required permissions or not
+   */
+  result: boolean;
+  /**
+   * optional message explaining the reason for failure in special cases
+   */
+  message?: string;
+}

--- a/src/api/procedures/__tests__/applyIncomingAssetBalance.ts
+++ b/src/api/procedures/__tests__/applyIncomingAssetBalance.ts
@@ -5,13 +5,11 @@ import {
   getAuthorization,
   prepareApplyIncomingBalance,
 } from '~/api/procedures/applyIncomingAssetBalance';
-import { Context, PolymeshError } from '~/internal';
+import { ConfidentialAccount, Context, PolymeshError } from '~/internal';
 import { dsMockUtils, entityMockUtils, procedureMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import { ApplyIncomingBalanceParams, ConfidentialAsset, TxTags } from '~/types';
 import * as utilsConversionModule from '~/utils/conversion';
-
-import { ConfidentialAccount } from './../../entities/types';
 
 describe('applyIncomingAssetBalance procedure', () => {
   let mockContext: Mocked<Context>;

--- a/src/api/procedures/createConfidentialAsset.ts
+++ b/src/api/procedures/createConfidentialAsset.ts
@@ -1,7 +1,6 @@
 import { ISubmittableResult } from '@polkadot/types/types';
 import { TransactionSpec } from '@polymeshassociation/polymesh-sdk/types/internal';
 import {
-  asIdentity,
   assertIdentityExists,
   filterEventRecords,
 } from '@polymeshassociation/polymesh-sdk/utils/internal';
@@ -15,7 +14,7 @@ import {
   meshConfidentialAssetToAssetId,
   stringToBytes,
 } from '~/utils/conversion';
-import { asConfidentialAccount } from '~/utils/internal';
+import { asConfidentialAccount, asIdentity } from '~/utils/internal';
 
 /**
  * @hidden

--- a/src/api/procedures/types.ts
+++ b/src/api/procedures/types.ts
@@ -1,5 +1,7 @@
 import { Identity } from '~/internal';
 import { ConfidentialAccount, ConfidentialAsset } from '~/types';
+
+export * from '@polymeshassociation/polymesh-sdk/api/procedures/types';
 export interface ConfidentialTransactionLeg {
   /**
    * The assets (or their IDs) for this leg of the transaction. Amounts are specified in the later proof generation steps

--- a/src/base/ConfidentialProcedure.ts
+++ b/src/base/ConfidentialProcedure.ts
@@ -21,12 +21,12 @@ import { signerToString } from '@polymeshassociation/polymesh-sdk/utils/conversi
 
 import { Identity } from '~/internal';
 import {
+  CheckPermissionsResult,
   ConfidentialCheckRolesResult,
   ConfidentialProcedureAuthorization,
   ConfidentialProcedureAuthorizationStatus,
   TxTag,
 } from '~/types';
-import { CheckPermissionsResult } from '~/types/internal';
 import { checkConfidentialPermissions, checkConfidentialRoles } from '~/utils/internal';
 
 /**

--- a/src/base/ConfidentialProcedure.ts
+++ b/src/base/ConfidentialProcedure.ts
@@ -8,7 +8,7 @@ import {
 import {
   ErrorCode,
   GenericPolymeshTransaction,
-  Identity,
+  Identity as PublicIdentity,
   ProcedureOpts,
   SignerType,
   TxTag as PublicTxTag,
@@ -19,6 +19,7 @@ import {
 } from '@polymeshassociation/polymesh-sdk/types/internal';
 import { signerToString } from '@polymeshassociation/polymesh-sdk/utils/conversion';
 
+import { Identity } from '~/internal';
 import {
   ConfidentialCheckRolesResult,
   ConfidentialProcedureAuthorization,
@@ -54,7 +55,7 @@ async function getAgentPermissionsResult(
         asset,
         transactions: transactions as PublicTxTag[],
       })
-    : { result: false, missingPermissions: transactions as PublicTxTag[] };
+    : { result: false, missingPermissions: transactions };
 }
 
 /**
@@ -183,7 +184,7 @@ export class ConfidentialProcedure<
 
     const account = ctx.getSigningAccount();
 
-    const fetchIdentity = async (): Promise<Identity | null> => {
+    const fetchIdentity = async (): Promise<PublicIdentity | null> => {
       if (identity) return identity;
 
       return account.getIdentity();
@@ -194,7 +195,7 @@ export class ConfidentialProcedure<
     } else if (typeof roles === 'string') {
       rolesResult = { result: false, message: roles };
     } else {
-      identity = await fetchIdentity();
+      identity = (await fetchIdentity()) as unknown as Identity;
       noIdentity = !identity;
       rolesResult = { result: false, missingRoles: roles };
 
@@ -230,7 +231,7 @@ export class ConfidentialProcedure<
       if (assets?.length && transactions?.length) {
         assertOnlyOneAsset(assets);
 
-        identity = await fetchIdentity();
+        identity = (await fetchIdentity()) as unknown as Identity;
 
         noIdentity = !identity;
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -2,6 +2,7 @@
 
 export * from '@polymeshassociation/polymesh-sdk/internal';
 
+export { Identity } from '~/api/entities/Identity';
 export { ConfidentialProcedure } from '~/base/ConfidentialProcedure';
 export { addConfidentialTransaction } from '~/api/procedures/addConfidentialTransaction';
 export { executeConfidentialTransaction } from '~/api/procedures/executeConfidentialTransaction';

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -172,8 +172,12 @@ import {
 } from '~/polkadot/polymesh';
 import { dsMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
-import { ConfidentialCheckRolesResult, CountryCode as CountryCodeEnum } from '~/types';
-import { CheckPermissionsResult, Consts, Extrinsics, Queries, Rpcs } from '~/types/internal';
+import {
+  CheckPermissionsResult,
+  ConfidentialCheckRolesResult,
+  CountryCode as CountryCodeEnum,
+} from '~/types';
+import { Consts, Extrinsics, Queries, Rpcs } from '~/types/internal';
 import { ArgsType, Mutable, tuple } from '~/types/utils';
 import { STATE_RUNTIME_VERSION_CALL, SYSTEM_VERSION_RPC_CALL } from '~/utils/constants';
 

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -13,7 +13,6 @@ import {
   AssetWithGroup,
   Authorization,
   AuthorizationType,
-  CheckPermissionsResult,
   CheckRolesResult,
   CollectionKey,
   ComplianceRequirements,
@@ -102,6 +101,7 @@ import {
 import { entityMockUtils } from '~/testUtils/mocks';
 import { Mocked } from '~/testUtils/types';
 import {
+  CheckPermissionsResult,
   ConfidentialAssetBalance,
   ConfidentialAssetDetails,
   ConfidentialLeg,

--- a/src/testUtils/mocks/entities.ts
+++ b/src/testUtils/mocks/entities.ts
@@ -1,8 +1,10 @@
 /* istanbul ignore file */
+
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-use-before-define */
+import { Identity } from '@polymeshassociation/polymesh-sdk/internal';
 import {
   AccountBalance,
   ActiveTransferRestrictions,
@@ -82,7 +84,7 @@ import {
   DefaultPortfolio,
   DividendDistribution,
   FungibleAsset,
-  Identity,
+  Identity as PrivateIdentity,
   Instruction,
   KnownPermissionGroup,
   MetadataEntry,
@@ -110,7 +112,7 @@ import {
   ConfidentialVenueFilteringDetails,
 } from '~/types';
 
-export type MockIdentity = Mocked<Identity>;
+export type MockIdentity = Mocked<PrivateIdentity>;
 export type MockChildIdentity = Mocked<ChildIdentity>;
 export type MockAccount = Mocked<Account>;
 export type MockSubsidy = Mocked<Subsidy>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,7 @@ import { CheckPermissionsResult } from '~/types/internal';
 
 export { EventRecord } from '@polkadot/types/interfaces';
 export { ConnectParams } from '~/api/client/Polymesh';
+export * from '@polymeshassociation/polymesh-sdk/api/client/types';
 export * from '~/api/entities/types';
 export * from '~/api/procedures/types';
 export * from '@polymeshassociation/polymesh-sdk/base/types';
@@ -52,7 +53,6 @@ export {
 export { CountryCode, ModuleName, TxTag, TxTags };
 
 // Roles
-
 export enum RoleType {
   TickerOwner = 'TickerOwner',
   CddProvider = 'CddProvider',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,7 @@ import {
 import BigNumber from 'bignumber.js';
 
 import { CountryCode, ModuleName, TxTag, TxTags } from '~/generated/types';
-import { CheckPermissionsResult } from '~/types/internal';
+import { CheckPermissionsResult } from '~/types';
 
 export { EventRecord } from '@polkadot/types/interfaces';
 export { ConnectParams } from '~/api/client/Polymesh';

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -8,14 +8,6 @@ import {
   SubmittableExtrinsics,
 } from '@polkadot/api/types';
 import { RpcInterface } from '@polkadot/rpc-core/types';
-import { BaseAsset } from '@polymeshassociation/polymesh-sdk/internal';
-import {
-  DefaultPortfolio,
-  NumberedPortfolio,
-  SignerType,
-} from '@polymeshassociation/polymesh-sdk/types';
-
-import { TxTag } from '~/generated/types';
 
 /**
  * Polkadot's `tx` submodule
@@ -49,40 +41,3 @@ export type Queries = QueryableStorage<'promise'>;
 export type Consts = QueryableConsts<'promise'>;
 
 export type Rpcs = DecoratedRpc<'promise', RpcInterface>;
-
-/**
- * This represents positive permissions (i.e. only "includes"). It is used
- *   for specifying procedure requirements and querying if an Account has certain
- *   permissions. Null values represent full permissions in that category
- */
-export interface SimplePermissions {
-  /**
-   * list of required Asset permissions
-   */
-  assets?: BaseAsset[] | null;
-  /**
-   * list of required Transaction permissions
-   */
-  transactions?: TxTag[] | null;
-  portfolios?: (DefaultPortfolio | NumberedPortfolio)[] | null;
-}
-
-/**
- * Result of a `checkPermissions` call. If `Type` is `Account`, represents whether the Account
- *   has all the necessary secondary key Permissions. If `Type` is `Identity`, represents whether the
- *   Identity has all the necessary external agent Permissions
- */
-export interface CheckPermissionsResult<Type extends SignerType> {
-  /**
-   * required permissions which the signer *DOESN'T* have. Only present if `result` is `false`
-   */
-  missingPermissions?: Type extends SignerType.Account ? SimplePermissions : TxTag[] | null;
-  /**
-   * whether the signer complies with the required permissions or not
-   */
-  result: boolean;
-  /**
-   * optional message explaining the reason for failure in special cases
-   */
-  message?: string;
-}

--- a/src/utils/__tests__/internal.ts
+++ b/src/utils/__tests__/internal.ts
@@ -31,6 +31,7 @@ import * as utilsInternalModule from '~/utils/internal';
 import {
   asConfidentialAccount,
   asConfidentialAsset,
+  asIdentity,
   assertCaAssetValid,
   assertElgamalPubKeyValid,
   checkConfidentialPermissions,
@@ -79,6 +80,25 @@ jest.mock(
     '@polymeshassociation/polymesh-sdk//api/entities/Venue'
   )
 );
+
+describe('asIdentity', () => {
+  it('should return identity instance', () => {
+    const mockContext = dsMockUtils.getContextInstance();
+
+    const did = 'did';
+    const identity = entityMockUtils.getIdentityInstance({
+      did,
+    });
+
+    let result = asIdentity(did, mockContext);
+
+    expect(result).toEqual(expect.objectContaining({ did }));
+
+    result = asIdentity(identity, mockContext);
+
+    expect(result).toEqual(expect.objectContaining({ did }));
+  });
+});
 
 describe('createProcedureMethod', () => {
   let context: Context;

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -63,6 +63,11 @@ import {
 
 export * from '~/generated/utils';
 
+export {
+  stringToIdentityId,
+  u64ToBigNumber,
+} from '@polymeshassociation/polymesh-sdk/utils/conversion';
+
 /**
  * @hidden
  */

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -6,7 +6,6 @@ import {
   DefaultPortfolio,
   ErrorCode,
   GenericPolymeshTransaction,
-  Identity,
   NumberedPortfolio,
   PermissionType,
   ProcedureOpts,
@@ -34,6 +33,7 @@ import {
   ConfidentialAsset,
   ConfidentialVenue,
   Context,
+  Identity,
   PolymeshError,
   TickerReservation,
   Venue,
@@ -55,6 +55,14 @@ import { ConfidentialProcedureFunc } from '~/types/utils';
 import { isConfidentialAssetOwnerRole, isConfidentialVenueOwnerRole } from '~/utils';
 
 export * from '~/generated/utils';
+
+/**
+ * @hidden
+ * Given a DID return the corresponding Identity, given an Identity return the Identity
+ */
+export function asIdentity(value: string | Identity, context: Context): Identity {
+  return typeof value === 'string' ? new Identity({ did: value }, context) : value;
+}
 
 /**
  * @hidden
@@ -565,7 +573,11 @@ export const checkConfidentialPermissions = async (
 /**
  * Check whether an Identity possesses the specified Role
  */
-const hasRole = async (identity: Identity, role: Role, context: Context): Promise<boolean> => {
+const hasRole = async <T extends Identity>(
+  identity: T,
+  role: Role,
+  context: Context
+): Promise<boolean> => {
   const { did } = identity;
 
   if (isConfidentialAssetOwnerRole(role)) {
@@ -625,8 +637,8 @@ const hasRole = async (identity: Identity, role: Role, context: Context): Promis
 /**
  * Check whether this Identity possesses all specified roles
  */
-export const checkConfidentialRoles = async (
-  identity: Identity,
+export const checkConfidentialRoles = async <T extends Identity>(
+  identity: T,
   roles: Role[],
   context: Context
 ): Promise<ConfidentialCheckRolesResult> => {

--- a/src/utils/internal.ts
+++ b/src/utils/internal.ts
@@ -39,6 +39,7 @@ import {
   Venue,
 } from '~/internal';
 import {
+  CheckPermissionsResult,
   ConfidentialCheckRolesResult,
   ConfidentialNoArgsProcedureMethod,
   ConfidentialOptionalArgsProcedureMethod,
@@ -46,11 +47,11 @@ import {
   ConfidentialProcedureMethod,
   ModuleName,
   Role,
+  SimplePermissions,
   TransactionPermissions,
   TxTag,
   TxTags,
 } from '~/types';
-import { CheckPermissionsResult, SimplePermissions } from '~/types/internal';
 import { ConfidentialProcedureFunc } from '~/types/utils';
 import { isConfidentialAssetOwnerRole, isConfidentialVenueOwnerRole } from '~/utils';
 

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -2,6 +2,8 @@
 
 import { ConfidentialAssetOwnerRole, ConfidentialVenueOwnerRole, Role, RoleType } from '~/types';
 
+export * from '@polymeshassociation/polymesh-sdk/utils';
+
 /**
  * Return whether Role is VenueOwnerRole
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,28 +4,16 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
-      "~/*": [
-        "src/*"
-      ],
-      "polymesh-types/*": [
-        "src/polkadot/*"
-      ],
-      "@polkadot/api/augment": [
-        "src/polkadot/augment-api.ts"
-      ],
-      "@polkadot/types/augment": [
-        "src/polkadot/augment-types.ts"
-      ],
-      "@polkadot/types/lookup": [
-        "src/polkadot/types-lookup.ts"
-      ]
+      "~/*": ["src/*"],
+      "polymesh-types/*": ["src/polkadot/*"],
+      "@polkadot/api/augment": ["src/polkadot/augment-api.ts"],
+      "@polkadot/types/augment": ["src/polkadot/augment-types.ts"],
+      "@polkadot/types/lookup": ["src/polkadot/types-lookup.ts"]
     },
     "plugins": [
       {
         "transform": "@ovos-media/ts-transform-paths",
-        "exclude": [
-          "*"
-        ],
+        "exclude": ["*"]
       }
     ],
     "useUnknownInCatchVariables": false,
@@ -40,20 +28,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
-    "typeRoots": [
-      "./node_modules/@types",
-      "./src/typings"
-    ]
+    "lib": ["es2017", "dom"],
+    "typeRoots": ["./node_modules/@types", "./src/typings"]
   },
-  "exclude": [
-    "dist",
-    "node_modules",
-    "src/sandbox.ts",
-    "test.ts",
-    "src-temp"
-  ]
+  "exclude": ["dist", "node_modules", "sandbox.ts", "test.ts", "src-temp"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,10 +2261,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.2.0"
 
-"@polymeshassociation/polymesh-sdk@24.1.0":
-  version "24.1.0"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.1.0.tgz#542e8fa43f830578988659ba50732ed97a36109f"
-  integrity sha512-8v4+WDX8f1PVxCWdfrNnftriyjSrMT5I8zysxRBCHwNv/riP/3BpqFkdhipg3ksR+5GCYER6ghiFB1Mw0rbh1w==
+"@polymeshassociation/polymesh-sdk@24.2.1":
+  version "24.2.1"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.2.1.tgz#3fd4c8da94e39b80e2778bdc3c62b17348d6c331"
+  integrity sha512-mKFqSEC98akG+F/50alDLXnOD/VrkKdf5pXRM6KRY0OCJxOV0JYfEk23NApHx/OCgzu9CiTHElgBMjoRywAp3A==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "10.9.1"


### PR DESCRIPTION
### Description

After the refactoring, all the entities and types were missing when PP SDK was included as a dependency in another project. This PR exports all the entities, constants and types which were present in public SDK, to resolve the issue.

### Breaking Changes

NA

### JIRA Link

DA-1151

### Checklist

- [ ] Updated the Readme.md (if required) ?
