### PR TITLE
feat: 🎸 add `getProofDetails` to `ConfidentialTransaction`

### DIFF
--- a/src/api/entities/ConfidentialTransaction/types.ts
+++ b/src/api/entities/ConfidentialTransaction/types.ts
@@ -125,9 +125,36 @@ export type AffirmConfidentialTransactionParams = { legId: BigNumber } & (
 export interface SenderAssetProof {
   proof: string;
   assetId: string;
+  auditors: ConfidentialAccount[];
 }
 
 export type SenderProofs = {
   legId: BigNumber;
+  sender: ConfidentialAccount;
+  receiver: ConfidentialAccount;
   proofs: SenderAssetProof[];
 };
+
+export interface PendingAssetProof {
+  assetId: string;
+  auditors: ConfidentialAccount[];
+}
+
+export type PendingProof = {
+  legId: BigNumber;
+  sender: ConfidentialAccount;
+  receiver: ConfidentialAccount;
+  proofs: PendingAssetProof[];
+};
+
+export interface TransactionProofDetails {
+  /**
+   * The legs referenced in `proved` will contain a proof for each asset. The receiver is able to decrypt all amounts with their private key. Auditors are able to decrypt the proof for the associated asset.
+   */
+  proved: SenderProofs[];
+
+  /**
+   * The legs in `pending` have not yet received a proof from the sender. For these the sender has yet to commit amounts on chain, so there is no proof to decrypt
+   */
+  pending: PendingProof[];
+}

--- a/src/api/entities/__tests__/ConfidentialTransaction/index.ts
+++ b/src/api/entities/__tests__/ConfidentialTransaction/index.ts
@@ -641,42 +641,146 @@ describe('ConfidentialTransaction class', () => {
     });
   });
 
-  describe('method: getSenderProofs', () => {
+  describe('method: getLegProofDetails', () => {
     it('should return the query results', async () => {
-      const senderProofsResult = {
-        confidentialTransactionAffirmations: {
-          nodes: [
-            {
-              legId: 1,
-              proofs: [
-                {
-                  assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa',
-                  proof: '0xsomeProof',
-                },
-              ],
-            },
-          ],
+      const legProofResult = {
+        confidentialTransaction: {
+          affirmations: {
+            nodes: [
+              {
+                legId: 0,
+                proofs: [
+                  {
+                    assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa',
+                    proof: '0xsomeProof',
+                  },
+                ],
+              },
+            ],
+          },
+          legs: {
+            nodes: [
+              {
+                id: '1/0',
+                senderId: 'someSender',
+                receiverId: 'someReceiver',
+                assetAuditors: [
+                  { assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa', auditors: ['someAuditor'] },
+                ],
+              },
+            ],
+          },
         },
       };
 
       dsMockUtils.createApolloQueryMock(
-        getConfidentialTransactionProofsQuery(transaction.id),
-        senderProofsResult
+        getConfidentialTransactionProofsQuery({ id: transaction.id.toString() }),
+        legProofResult
       );
 
       const result = await transaction.getSenderProofs();
 
-      expect(result).toEqual([
-        {
-          legId: new BigNumber('1'),
-          proofs: [
-            {
-              assetId: '08abb6e3-550f-3857-21cf-d4a35bd5c6fa',
-              proof: '0xsomeProof',
-            },
-          ],
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            legId: new BigNumber('0'),
+            receiver: expect.objectContaining({ publicKey: 'someReceiver' }),
+            sender: expect.objectContaining({ publicKey: 'someSender' }),
+            proofs: expect.arrayContaining([
+              {
+                assetId: '08abb6e3-550f-3857-21cf-d4a35bd5c6fa',
+                proof: '0xsomeProof',
+                auditors: expect.arrayContaining([
+                  expect.objectContaining({ publicKey: 'someAuditor' }),
+                ]),
+              },
+            ]),
+          }),
+        ])
+      );
+    });
+  });
+
+  describe('method: getLegProofDetails', () => {
+    it('should return the query results', async () => {
+      const legProofResult = {
+        confidentialTransaction: {
+          affirmations: {
+            nodes: [
+              {
+                legId: 0,
+                proofs: [
+                  {
+                    assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa',
+                    proof: '0xsomeProof',
+                  },
+                ],
+              },
+            ],
+          },
+          legs: {
+            nodes: [
+              {
+                id: '1/0',
+                senderId: 'someSender',
+                receiverId: 'someReceiver',
+                assetAuditors: [
+                  { assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa', auditors: ['someAuditor'] },
+                ],
+              },
+              {
+                id: '1/1',
+                senderId: 'someSender',
+                receiverId: 'someReceiver',
+                assetAuditors: [
+                  { assetId: '0x08abb6e3550f385721cfd4a35bd5c6fa', auditors: ['someAuditor'] },
+                ],
+              },
+            ],
+          },
         },
-      ]);
+      };
+
+      dsMockUtils.createApolloQueryMock(
+        getConfidentialTransactionProofsQuery({ id: transaction.id.toString() }),
+        legProofResult
+      );
+
+      const result = await transaction.getProofDetails();
+
+      expect(result).toEqual({
+        proved: expect.arrayContaining([
+          expect.objectContaining({
+            legId: new BigNumber('0'),
+            receiver: expect.objectContaining({ publicKey: 'someReceiver' }),
+            sender: expect.objectContaining({ publicKey: 'someSender' }),
+            proofs: expect.arrayContaining([
+              {
+                assetId: '08abb6e3-550f-3857-21cf-d4a35bd5c6fa',
+                proof: '0xsomeProof',
+                auditors: expect.arrayContaining([
+                  expect.objectContaining({ publicKey: 'someAuditor' }),
+                ]),
+              },
+            ]),
+          }),
+        ]),
+        pending: expect.arrayContaining([
+          expect.objectContaining({
+            legId: new BigNumber('1'),
+            receiver: expect.objectContaining({ publicKey: 'someReceiver' }),
+            sender: expect.objectContaining({ publicKey: 'someSender' }),
+            proofs: expect.arrayContaining([
+              {
+                assetId: '08abb6e3-550f-3857-21cf-d4a35bd5c6fa',
+                auditors: expect.arrayContaining([
+                  expect.objectContaining({ publicKey: 'someAuditor' }),
+                ]),
+              },
+            ]),
+          }),
+        ]),
+      });
     });
   });
 

--- a/src/middleware/queries/confidential.ts
+++ b/src/middleware/queries/confidential.ts
@@ -271,58 +271,6 @@ export function getConfidentialAssetHistoryByConfidentialAccountQuery(
   };
 }
 
-export type ConfidentialTransactionProofsArgs = {
-  transactionId: string;
-};
-
-/**
- * @hidden
- */
-function createGetConfidentialTransactionProofArgs(transactionId: BigNumber): {
-  args: string;
-  filter: string;
-  variables: { transactionId: string };
-} {
-  const args = ['$transactionId: String!'];
-  const filter = ['transactionId: { equalTo: $transactionId }, party: { equalTo: Sender }'];
-
-  return {
-    args: `(${args.join()})`,
-    filter: `filter: { ${filter.join()} }`,
-    variables: { transactionId: transactionId.toString() },
-  };
-}
-
-/**
- * @hidden
- *
- * Get sender proofs for a transaction
- */
-export function getConfidentialTransactionProofsQuery(
-  transactionId: BigNumber
-): QueryOptions<ConfidentialTransactionProofsArgs> {
-  const { args, filter, variables } = createGetConfidentialTransactionProofArgs(transactionId);
-
-  const query = gql`
-  query ConfidentialTransactionProofs
-  ${args}
-  {
-    confidentialTransactionAffirmations(
-      ${filter}
-  ) {
-    nodes {
-      proofs
-      legId
-    }
-  }
-  }`;
-
-  return {
-    query,
-    variables,
-  };
-}
-
 /**
  * @hidden
  *
@@ -339,6 +287,42 @@ export function confidentialTransactionQuery(
           blockId
           datetime
           hash
+        }
+      }
+    }
+  `;
+
+  return {
+    query,
+    variables,
+  };
+}
+
+/**
+ * @hidden
+ *
+ * Get confidential transaction details by ID
+ */
+export function getConfidentialTransactionProofsQuery(
+  variables: QueryArgs<ConfidentialTransaction, 'id'>
+): QueryOptions<QueryArgs<ConfidentialTransaction, 'id'>> {
+  const query = gql`
+    query ConfidentialTransaction($id: String!) {
+      confidentialTransaction(id: $id) {
+        eventIdx
+        affirmations(filter: { party: { equalTo: Sender } }) {
+          nodes {
+            proofs
+            legId
+          }
+        }
+        legs {
+          nodes {
+            id
+            senderId
+            receiverId
+            assetAuditors
+          }
         }
       }
     }


### PR DESCRIPTION
### Description

allow fetching all proof information related to a confidential transaction. The new method is similar to `getSenderProofs`, except it also includes details about legs where the sender has not committed proofs for the assets

### Breaking Changes

None

### JIRA Link

[DA-1143](https://polymesh.atlassian.net/browse/DA-1143)

### Checklist

- [ ] Updated the Readme.md (if required) ?


[DA-1143]: https://polymesh.atlassian.net/browse/DA-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ