### PR TITLE
feat: 🎸 Return balance info when applying incoming balance

### DIFF
--- a/src/api/client/ConfidentialAccounts.ts
+++ b/src/api/client/ConfidentialAccounts.ts
@@ -12,6 +12,7 @@ import {
   ApplyIncomingConfidentialAssetBalancesParams,
   ConfidentialProcedureMethod,
   CreateConfidentialAccountParams,
+  IncomingConfidentialAssetBalance,
 } from '~/types';
 import { createConfidentialProcedureMethod } from '~/utils/internal';
 
@@ -84,7 +85,7 @@ export class ConfidentialAccounts {
    */
   public applyIncomingBalance: ConfidentialProcedureMethod<
     ApplyIncomingBalanceParams,
-    ConfidentialAccount
+    IncomingConfidentialAssetBalance
   >;
 
   /**
@@ -92,6 +93,6 @@ export class ConfidentialAccounts {
    */
   public applyIncomingBalances: ConfidentialProcedureMethod<
     ApplyIncomingConfidentialAssetBalancesParams,
-    ConfidentialAccount
+    IncomingConfidentialAssetBalance[]
   >;
 }

--- a/src/api/entities/ConfidentialAccount/types.ts
+++ b/src/api/entities/ConfidentialAccount/types.ts
@@ -48,3 +48,18 @@ export interface ApplyIncomingConfidentialAssetBalancesParams {
    */
   maxUpdates?: BigNumber;
 }
+
+export interface IncomingConfidentialAssetBalance {
+  /**
+   * Confidential Asset whose balance has been applied
+   */
+  asset: ConfidentialAsset;
+  /**
+   * Encrypted amount that was applied
+   */
+  amount: string;
+  /**
+   * Encrypted balance after the `amount` was applied
+   */
+  balance: string;
+}


### PR DESCRIPTION
### Description

Return balance info when applying incoming balance

### Breaking Changes

On applying incoming balance(s) for an account, the method now returns details about the confidential asset, the amount being applied and balance after amount is deposited.
- `confidentialAccounts.applyIncomingBalance` returns `IncomingConfidentialAssetBalance`
- `confidentialAccounts.applyIncomingBalances` returns `IncomingConfidentialAssetBalance[]`

### JIRA Link

DA-1264

### Checklist

- [ ] Updated the Readme.md (if required) ?
