### PR TITLE
feat: 🎸 update newest SDK changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@polkadot/api": "11.2.1",
     "@polkadot/util": "12.6.2",
     "@polkadot/util-crypto": "12.6.2",
-    "@polymeshassociation/polymesh-sdk": "26.2.0",
+    "@polymeshassociation/polymesh-sdk": "27.0.0",
     "bignumber.js": "9.0.1",
     "bluebird": "^3.7.2",
     "cross-fetch": "^4.0.0",

--- a/src/testUtils/mocks/dataSources.ts
+++ b/src/testUtils/mocks/dataSources.ts
@@ -653,6 +653,7 @@ const defaultContextOptions: ContextOptions = {
     lastProcessedTimestamp: new Date('01/06/2023'),
     targetHeight: new BigNumber(10000),
     indexerHealthy: true,
+    paddedIds: false,
   },
 };
 let contextOptions: ContextOptions = defaultContextOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.2.0"
 
-"@polymeshassociation/polymesh-sdk@26.2.0":
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-26.2.0.tgz#09217c23b9a390c7a3adb198494bf11af1b182d3"
-  integrity sha512-1zdaaAWVu5PgcajMokgzcsf0vjQsaC9v+ILu193JAfZbwKSEPx4y+KSsK0kehMF93tm+K1jU3uMYWsefHgwpsg==
+"@polymeshassociation/polymesh-sdk@27.0.0":
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-27.0.0.tgz#7d193fa7c46de01fbd55d5335a23724d9a6eb4b9"
+  integrity sha512-eMg/A6U+TIzGH6vcnepT7d9Y7se8pHLpRaPoO8goUx4HvTm5oB9qnlqwhcwqNLxzVlC33JavTTr2xQtck1Zo0g==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "11.2.1"
@@ -2320,7 +2320,6 @@
     iso-7064 "^1.1.0"
     json-stable-stringify "^1.0.2"
     lodash "^4.17.21"
-    patch-package "^8.0.0"
     semver "^7.5.4"
     websocket "^1.0.34"
 


### PR DESCRIPTION
### Description

update SDK to v27

### Breaking Changes

See public release notes for full change log: https://github.com/PolymeshAssociation/polymesh-sdk/releases/tag/v27.0.0

None in the confidential APIs, however in the public API has some minor changes:
🧨 InstructionDetails.createdAt is nullable
🧨 venueId is now optional in HistoricInstruction. This affects the
methods getHistoricInstructions in Identity entity
🧨 ticker, did has been deprecated in BaseAsset. To get the ticker
associated with an Asset, use BaseAsset.details method which now
returns ticker along with other Asset details
🧨 - Since its not mandatory to specify a ticker while creating an Asset,
ticker field in BaseAsset is now optional. did field in BaseAsset is now also optional.

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
